### PR TITLE
Typo: Removed wrong && symbol

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
       allow list: if request.auth.uid != null;
       
       allow create: if request.auth.uid != null &&
-                    request.auth.uid == uid &&;
+                    request.auth.uid == uid;
 
       allow update: if request.auth.uid != null &&
                        request.auth.uid == uid;

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
       allow list: if request.auth.uid != null;
       
       allow create: if request.auth.uid != null &&
-                    request.auth.uid == uid;
+                       request.auth.uid == uid;
 
       allow update: if request.auth.uid != null &&
                        request.auth.uid == uid;


### PR DESCRIPTION
Typo error: we can not add  && symbol in the end